### PR TITLE
Enclosing the omapi secret parameter in "quotes" is a syntax error (#…

### DIFF
--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -140,7 +140,7 @@ describe 'dhcp', type: :class do
           end
 
           it 'sets key secret' do
-            is_expected.to contain_concat__fragment('dhcp-conf-header').with_content(%r{^\s*secret "keyvalue";})
+            is_expected.to contain_concat__fragment('dhcp-conf-header').with_content(%r{^\s*secret keyvalue;})
           end
         end
       end

--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -12,7 +12,7 @@ omapi-port <%= @omapi_port %>;
 <% if @omapi_name && @omapi_key -%>
 key <%= @omapi_name %> {
   algorithm <%= @omapi_algorithm %>;
-  secret "<%= @omapi_key %>";
+  secret <%= @omapi_key %>;
 }
 omapi-key <%= @omapi_name %>;
 <% end -%>


### PR DESCRIPTION
…179)

Looks like this parameter has to be unquoted:
```
Apr  9 16:09:53 dhcp-ztp0 puppet-agent[17478]: Apr 09 16:09:53 dhcp-ztp0.ab2.staging.gigaclear.net dhcpd[17715]: /etc/dhcp/dhcpd.conf line 9: invalid base64 character 32.
Apr  9 16:09:53 dhcp-ztp0 puppet-agent[17478]: Apr 09 16:09:53 dhcp-ztp0.ab2.staging.gigaclear.net dhcpd[17715]:   secret "juZ33DXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
Apr  9 16:09:53 dhcp-ztp0 puppet-agent[17478]: Apr 09 16:09:53 dhcp-ztp0.ab2.staging.gigaclear.net dhcpd[17715]:           ^
```
```
# dhcpd -v
Internet Systems Consortium DHCP Server 4.2.5
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
